### PR TITLE
Gate pr with github reviews

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -2504,7 +2504,6 @@ func (obj *MungeObject) CollectGHReviewStatus() ([]*github.PullRequestReview, []
 		if r, exist := latestReviews[reviewer]; !exist || r.GetSubmittedAt().Before(review.GetSubmittedAt()) {
 			latestReviews[reviewer] = review
 		}
-
 	}
 
 	for _, review := range latestReviews {

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -53,6 +53,9 @@ const (
 	headerRateReset     = "X-RateLimit-Reset"
 
 	maxCommentLen = 65535
+
+	ghApproved         = "APPROVED"
+	ghChangesRequested = "CHANGES_REQUESTED"
 )
 
 var (
@@ -2486,6 +2489,32 @@ func (obj *MungeObject) ListReviews() ([]*github.PullRequestReview, bool) {
 	}
 	obj.prReviews = allReviews
 	return allReviews, true
+}
+
+func (obj *MungeObject) CollectGHReviewStatus() ([]*github.PullRequestReview, []*github.PullRequestReview, bool) {
+	reviews, ok := obj.ListReviews()
+	if !ok {
+		glog.Warning("Cannot get all reviews")
+		return nil, nil, false
+	}
+	var approvedReviews, changesRequestReviews []*github.PullRequestReview
+	latestReviews := make(map[string]*github.PullRequestReview)
+	for _, review := range reviews {
+		reviewer := review.User.GetLogin()
+		if r, exist := latestReviews[reviewer]; !exist || r.GetSubmittedAt().Before(review.GetSubmittedAt()) {
+			latestReviews[reviewer] = review
+		}
+
+	}
+
+	for _, review := range latestReviews {
+		if review.GetState() == ghApproved {
+			approvedReviews = append(approvedReviews, review)
+		} else if review.GetState() == ghChangesRequested {
+			changesRequestReviews = append(changesRequestReviews, review)
+		}
+	}
+	return approvedReviews, changesRequestReviews, true
 }
 
 func (config *Config) runMungeFunction(obj *MungeObject, fn MungeFunction) error {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1077,15 +1077,17 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 		}
 	}
 
-	if approvedReview, changesRequestedReview, ok := obj.CollectGHReviewStatus(); !ok && (sq.GateGHReviewApproved || sq.GateGHReviewChangesRequested) {
-		sq.SetMergeStatus(obj, ghReviewStateUnclear)
-		return false
-	} else if len(approvedReview) == 0 && sq.GateGHReviewApproved {
-		sq.SetMergeStatus(obj, ghReviewApproved)
-		return false
-	} else if len(changesRequestedReview) > 0 && sq.GateGHReviewChangesRequested {
-		sq.SetMergeStatus(obj, ghReviewChangesRequested)
-		return false
+	if sq.GateGHReviewApproved || sq.GateGHReviewChangesRequested {
+		if approvedReview, changesRequestedReview, ok := obj.CollectGHReviewStatus(); !ok {
+			sq.SetMergeStatus(obj, ghReviewStateUnclear)
+			return false
+		} else if len(approvedReview) == 0 && sq.GateGHReviewApproved {
+			sq.SetMergeStatus(obj, ghReviewApproved)
+			return false
+		} else if len(changesRequestedReview) > 0 && sq.GateGHReviewChangesRequested {
+			sq.SetMergeStatus(obj, ghReviewChangesRequested)
+			return false
+		}
 	}
 
 	if !obj.HasLabel(lgtmLabel) {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -987,6 +987,8 @@ const (
 	ghE2EFailed             = "Second github e2e run failed."
 	unmergeableMilestone    = "Milestone is for a future release and cannot be merged"
 	headCommitChanged       = "This PR has changed since we ran the tests"
+	ghReviewStateUnclear    = "Cannot get gh reviews status"
+	ghReview                = "This pr has no gh approve or has changes request"
 )
 
 // validForMergeExt is the base logic about what PR can be automatically merged.
@@ -1068,6 +1070,14 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 				return false
 			}
 		}
+	}
+
+	if approvedReview, changesRequestedReview, ok := obj.CollectGHReviewStatus(); !ok {
+		sq.SetMergeStatus(obj, ghReviewStateUnclear)
+		return false
+	} else if len(approvedReview) == 0 || len(changesRequestedReview) > 0 {
+		sq.SetMergeStatus(obj, ghReview)
+		return false
 	}
 
 	if !obj.HasLabel(lgtmLabel) {


### PR DESCRIPTION
Add a easy check to get github reviews, and gate merge if:
1. No gh "approve"
2. At least one gh "change request"

PR based on k8s/master Aug.16, SHA:bf8cfc5190da8c5b346a294a88e87bd50a8d41e2
This is the version we are currently deployed for istio all repos. The reason why not rebase from upstream is we are not ready to introduce new feather changes until we are aware of what are they. 

Note: it's a quick fix. Since we are testing only gate "lgtm" in pilot and there is a risk robot accidently merges due to a irresponsible "/lgtm" ("/lgtm" is cheap, anyone in the org can do that.)

@sebastienvas @foxish  @cjwagner  Please take a look at and point out logic issues or so. And let's talk about if it is something you guys want as a configurable feature. I will definite refine it before trying to merge to upstream.

fixes https://github.com/istio/test-infra/issues/453